### PR TITLE
Update shared variable example

### DIFF
--- a/27_thread_shared_var/CMakeLists.txt
+++ b/27_thread_shared_var/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(00-blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/27_thread_shared_var/prj.conf
+++ b/27_thread_shared_var/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_LOG=y

--- a/27_thread_shared_var/src/main.c
+++ b/27_thread_shared_var/src/main.c
@@ -1,0 +1,36 @@
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/random.h>
+
+LOG_MODULE_REGISTER(prod_cons_bad, LOG_LEVEL_INF);
+
+static uint32_t shared_data;
+
+void producer_thread(void)
+{
+    while (1) {
+        shared_data = sys_rand32_get();
+        LOG_INF("Produced data: %u", shared_data);
+        k_msleep(1000);
+    }
+}
+
+void consumer_thread(void)
+{
+    while (1) {
+        LOG_INF("Consumed data: %u", shared_data);
+        k_msleep(100);
+    }
+}
+
+#define STACK_SIZE 1024
+#define PRIORITY 5
+
+K_THREAD_DEFINE(prod_tid, STACK_SIZE, producer_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(cons_tid, STACK_SIZE, consumer_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+
+int main(void)
+{
+    LOG_INF("Producer-Consumer example using shared variable");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- simplify producer-consumer example by removing `data_ready` flag
- producer still sleeps and consumer logs the shared value every loop

## Testing
- `west build -b xiao_ble_nrf52840_sense 27_thread_shared_var` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea702c1c8322a14f217b7fed913d