### PR TITLE
Add semaphore and mutex examples

### DIFF
--- a/29-thread_semaphore/CMakeLists.txt
+++ b/29-thread_semaphore/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(00-blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/29-thread_semaphore/prj.conf
+++ b/29-thread_semaphore/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_LOG=y

--- a/29-thread_semaphore/src/main.c
+++ b/29-thread_semaphore/src/main.c
@@ -1,0 +1,38 @@
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/random.h>
+
+LOG_MODULE_REGISTER(prod_cons_sem, LOG_LEVEL_INF);
+
+static uint32_t shared_data;
+K_SEM_DEFINE(data_sem, 0, 1);
+
+void producer_thread(void)
+{
+    while (1) {
+        shared_data = sys_rand32_get();
+        LOG_INF("Produced data: %u", shared_data);
+        k_sem_give(&data_sem);
+        k_msleep(1000);
+    }
+}
+
+void consumer_thread(void)
+{
+    while (1) {
+        k_sem_take(&data_sem, K_FOREVER);
+        LOG_INF("Consumed data: %u", shared_data);
+    }
+}
+
+#define STACK_SIZE 1024
+#define PRIORITY 5
+
+K_THREAD_DEFINE(prod_tid, STACK_SIZE, producer_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(cons_tid, STACK_SIZE, consumer_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+
+int main(void)
+{
+    LOG_INF("Producer-Consumer example using semaphore");
+    return 0;
+}

--- a/30-thread_mutex/CMakeLists.txt
+++ b/30-thread_mutex/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(00-blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/30-thread_mutex/prj.conf
+++ b/30-thread_mutex/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_LOG=y

--- a/30-thread_mutex/src/main.c
+++ b/30-thread_mutex/src/main.c
@@ -1,0 +1,41 @@
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(mutex_counter, LOG_LEVEL_INF);
+
+static uint32_t counter;
+K_MUTEX_DEFINE(counter_mutex);
+
+void increment_thread(void)
+{
+    while (1) {
+        k_mutex_lock(&counter_mutex, K_FOREVER);
+        counter++;
+        LOG_INF("Incremented counter: %u", counter);
+        k_mutex_unlock(&counter_mutex);
+        k_msleep(1000);
+    }
+}
+
+void decrement_thread(void)
+{
+    while (1) {
+        k_mutex_lock(&counter_mutex, K_FOREVER);
+        counter--;
+        LOG_INF("Decremented counter: %u", counter);
+        k_mutex_unlock(&counter_mutex);
+        k_msleep(1500);
+    }
+}
+
+#define STACK_SIZE 1024
+#define PRIORITY 5
+
+K_THREAD_DEFINE(inc_tid, STACK_SIZE, increment_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+K_THREAD_DEFINE(dec_tid, STACK_SIZE, decrement_thread, NULL, NULL, NULL, PRIORITY, 0, 0);
+
+int main(void)
+{
+    LOG_INF("Counter protected with mutex");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `29-thread_semaphore` sample to demonstrate semaphore usage
- add `30-thread_mutex` sample to demonstrate mutex usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68646fe435f083229ccc1b1c67d2832f