### PR TITLE
Add UART async FIFO example

### DIFF
--- a/35-uart_async_fifo/CMakeLists.txt
+++ b/35-uart_async_fifo/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(uart_async_fifo)
+
+target_sources(app PRIVATE src/main.c)

--- a/35-uart_async_fifo/boards/nrf52840dk_nrf52840.overlay
+++ b/35-uart_async_fifo/boards/nrf52840dk_nrf52840.overlay
@@ -1,0 +1,20 @@
+// UART pela USB
+/ {
+    aliases {
+        work-uart = &uart0;
+    };
+};
+
+
+
+// UART pelo conector Arduino
+// / {
+//     aliases {
+//         work-uart = &uart1;
+//     };
+// };
+
+
+// &uart1 {
+// 	status = "okay";
+// };

--- a/35-uart_async_fifo/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
+++ b/35-uart_async_fifo/boards/nrf54l15dk_nrf54l15_cpuapp_ns.overlay
@@ -1,0 +1,46 @@
+
+//UART pela USB
+/ {
+ 	aliases {
+ 		work-uart = &uart20;
+ 	};
+};
+
+
+// Uart pelo conector P1
+// / {
+// 	aliases {
+// 		work-uart = &uart21;
+// 	};
+// };
+
+
+// &uart21 {
+// 	status = "okay";
+// 	current-speed = <115200>;
+// 	pinctrl-0 = <&uart21_default>;
+// 	pinctrl-1 = <&uart21_sleep>;
+// 	pinctrl-names = "default", "sleep";
+// };
+
+// &pinctrl {
+
+// 	uart21_default: uart21_default {
+// 		group1 {
+// 			psels = <NRF_PSEL(UART_TX, 1, 11)>;
+// 		};
+// 		group2 {
+// 			psels = <NRF_PSEL(UART_RX, 1, 12)>;
+// 			bias-pull-up;
+// 		};
+// 	};
+
+// 	uart21_sleep: uart21_sleep {
+// 		group1 {
+// 			psels = <NRF_PSEL(UART_TX, 1, 11)>,
+// 				<NRF_PSEL(UART_RX, 1, 12)>;
+// 			low-power-enable;
+// 		};
+// 	};
+// };
+

--- a/35-uart_async_fifo/boards/xiao_ble_nrf52840_sense.overlay
+++ b/35-uart_async_fifo/boards/xiao_ble_nrf52840_sense.overlay
@@ -1,0 +1,6 @@
+//Uart pelo conector 
+/ {
+	aliases {
+		work-uart = &uart0;
+	};
+};

--- a/35-uart_async_fifo/pm_static_xiao_ble_nrf52840_sense.yml
+++ b/35-uart_async_fifo/pm_static_xiao_ble_nrf52840_sense.yml
@@ -1,0 +1,23 @@
+sd_partition:
+  address: 0x00000
+  end_address: 0x27000
+  region: flash_primary
+  size: 0x27000
+
+app:
+  address: 0x27000
+  end_address: 0xEC000
+  region: flash_primary
+  size: 0xC5000  # from 0x27000 to 0xEC000
+
+storage:
+  address: 0xEC000
+  end_address: 0xF4000
+  region: flash_primary
+  size: 0x8000
+
+adafruit_boot:
+  address: 0xF4000
+  end_address: 0x100000
+  region: flash_primary
+  size: 0xC000

--- a/35-uart_async_fifo/prj.conf
+++ b/35-uart_async_fifo/prj.conf
@@ -1,0 +1,9 @@
+# Serial configuration
+CONFIG_SERIAL=y
+CONFIG_UART_ASYNC_API=y
+
+# Logger
+CONFIG_LOG=y
+
+# Heap for dynamic allocation
+CONFIG_HEAP_MEM_POOL_SIZE=2048

--- a/35-uart_async_fifo/src/main.c
+++ b/35-uart_async_fifo/src/main.c
@@ -1,0 +1,134 @@
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
+#include <string.h>
+
+LOG_MODULE_REGISTER(uart_async_fifo, LOG_LEVEL_INF);
+
+/* Reserve first word for k_fifo */
+struct uart_item {
+    void *fifo_reserved;
+    size_t len;
+    char data[];
+};
+
+K_FIFO_DEFINE(uart_fifo);
+
+#define UART_NODE DT_ALIAS(work_uart)
+static const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+
+#define BUTTON_NODE DT_ALIAS(sw0)
+static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET(BUTTON_NODE, gpios);
+static struct gpio_callback button_cb_data;
+
+#define RX_BUF_SIZE 64
+static uint8_t rx_buf[RX_BUF_SIZE];
+static size_t rx_pos;
+
+static void dump_fifo(void)
+{
+    struct uart_item *item;
+
+    while ((item = k_fifo_get(&uart_fifo, K_NO_WAIT)) != NULL) {
+        LOG_INF("Received: %s", log_strdup(item->data));
+        k_free(item);
+        /* Comment out the line above to see the wrong way of using k_fifo */
+    }
+}
+
+static void button_pressed_isr(const struct device *dev, struct gpio_callback *cb,
+                               uint32_t pins)
+{
+    ARG_UNUSED(dev);
+    ARG_UNUSED(cb);
+    ARG_UNUSED(pins);
+
+    LOG_INF("Button pressed: dumping fifo");
+    dump_fifo();
+}
+
+static void uart_cb(const struct device *dev, struct uart_event *evt, void *user_data)
+{
+    ARG_UNUSED(dev);
+    ARG_UNUSED(user_data);
+
+    switch (evt->type) {
+    case UART_RX_RDY:
+        for (size_t i = 0; i < evt->data.rx.len; i++) {
+            char c = rx_buf[evt->data.rx.offset + i];
+            if (c == '\n' || c == '\r') {
+                struct uart_item *item =
+                    k_malloc(sizeof(struct uart_item) + rx_pos + 1);
+                /* Comment out the line above to see the wrong way of using k_fifo */
+                if (!item) {
+                    LOG_ERR("Allocation failed");
+                    rx_pos = 0;
+                    break;
+                }
+
+                item->len = rx_pos;
+                memcpy(item->data, rx_buf, rx_pos);
+                item->data[rx_pos] = '\0';
+
+                k_fifo_put(&uart_fifo, item);
+
+                rx_pos = 0;
+                uart_rx_disable(uart_dev);
+            } else if (rx_pos < RX_BUF_SIZE - 1) {
+                rx_buf[rx_pos++] = c;
+            }
+        }
+        break;
+
+    case UART_RX_DISABLED:
+        uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
+        break;
+
+    default:
+        break;
+    }
+}
+
+int main(void)
+{
+    int ret;
+
+    LOG_INF("UART async FIFO sample");
+
+    if (!device_is_ready(uart_dev) || !device_is_ready(button.port)) {
+        LOG_ERR("Devices not ready");
+        return -1;
+    }
+
+    ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure button");
+        return ret;
+    }
+
+    ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
+    if (ret < 0) {
+        LOG_ERR("Failed to configure button interrupt");
+        return ret;
+    }
+
+    gpio_init_callback(&button_cb_data, button_pressed_isr, BIT(button.pin));
+    gpio_add_callback(button.port, &button_cb_data);
+
+    ret = uart_callback_set(uart_dev, uart_cb, NULL);
+    if (ret) {
+        LOG_ERR("Failed to set UART callback");
+        return ret;
+    }
+
+    ret = uart_rx_enable(uart_dev, rx_buf, sizeof(rx_buf), 50);
+    if (ret) {
+        LOG_ERR("Failed to enable UART RX");
+        return ret;
+    }
+
+    return 0; /* everything runs via callbacks */
+}
+


### PR DESCRIPTION
## Summary
- add new sample 35 demonstrating UART async RX with k_fifo
- allocate received lines in the heap and store them in a FIFO
- press button to dump FIFO contents

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884d9fed874832299861b18181062d5